### PR TITLE
Adding coroutines

### DIFF
--- a/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
+++ b/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
@@ -56,8 +56,7 @@ class CapMLParser(
     }
 
     /**
-     * Takes the [capmlInputData] and opens a stream to it.
-     * Manually iterates through bytes.
+     * Takes the [capmlData] stream and manually iterates through bytes.
      * Looks for the .capml...decorators? Flags?
      * Once it has finished assembling the scrollview, executes a callback
      * using the view
@@ -66,10 +65,10 @@ class CapMLParser(
      */
     @Throws(CapmlFileFormatException::class, CapmlParseException::class)
     suspend fun parse(
-        capmlFile: InputStream,
+        capmlData: InputStream,
         callback:((View) -> Unit)
     ){
-        callback.invoke(parse(capmlFile))
+        callback.invoke(parse(capmData))
     }
 
 

--- a/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
+++ b/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
@@ -9,6 +9,8 @@ import android.widget.*
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.ddmac.capml.R
 import org.ddmac.capml.exceptions.CapmlFileFormatException
 import org.ddmac.capml.exceptions.CapmlParseException
@@ -44,7 +46,7 @@ class CapMLParser(
      * @return a [ScrollView] containing the elements, order maintained.
      */
     @Throws(CapmlFileFormatException::class, CapmlParseException::class)
-    fun parse(capmlFile: File): ScrollView {
+    suspend fun parse(capmlFile: File): ScrollView {
         return parse(capmlFile.inputStream())
     }
 
@@ -57,7 +59,7 @@ class CapMLParser(
      * @return a [ScrollView] containing the elements, order maintained.
      */
 
-    fun parse(capmlData: InputStream): ScrollView {
+    suspend fun parse(capmlData: InputStream): ScrollView = withContext(Dispatchers.IO){
         //LinearLayout to contain elements. Basic "Style"
         val ll = LinearLayout(ctx).apply {
             layoutParams = ViewGroup.LayoutParams(
@@ -116,7 +118,7 @@ class CapMLParser(
         capmlData.close()
 
         //Wrap the linear layout in a scroll view. Accounts for many elements. More "Style"
-        return ScrollView(ctx)
+        ScrollView(ctx)
             .apply {
                 layoutParams = ViewGroup.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,

--- a/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
+++ b/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
@@ -20,7 +20,6 @@ import java.io.InputStream
 import java.io.InputStreamReader
 import java.util.*
 import java.util.logging.Logger
-import kotlin.math.log
 
 /**
  * This class parses the .capml file
@@ -58,8 +57,10 @@ class CapMLParser(
      *
      * @return a [ScrollView] containing the elements, order maintained.
      */
-
-    suspend fun parse(capmlData: InputStream): ScrollView = withContext(Dispatchers.IO){
+    @Throws(CapmlFileFormatException::class, CapmlParseException::class)
+    suspend fun parse(
+        capmlData: InputStream
+    ): ScrollView = withContext(Dispatchers.IO){
         //LinearLayout to contain elements. Basic "Style"
         val ll = LinearLayout(ctx).apply {
             layoutParams = ViewGroup.LayoutParams(

--- a/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
+++ b/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
@@ -68,7 +68,7 @@ class CapMLParser(
         capmlData: InputStream,
         callback:((View) -> Unit)
     ){
-        callback.invoke(parse(capmData))
+        callback.invoke(parse(capmlData))
     }
 
 

--- a/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
+++ b/CapML/src/main/java/org/ddmac/capml/parser/CapMLParser.kt
@@ -37,6 +37,42 @@ class CapMLParser(
     //the data will go here.
     var data = JsonObject()
 
+
+    /**
+     * Takes the [capmlFile] and opens a stream to it.
+     * Manually iterates through bytes.
+     * Looks for the .capml...decorators? Flags?
+     * Once it has finished assembling the scrollview, executes a callback
+     * using the view
+     *
+     * @return [Unit]
+     */
+    @Throws(CapmlFileFormatException::class, CapmlParseException::class)
+    suspend fun parse(
+        capmlFile: File,
+        callback:((View) -> Unit)
+    ){
+        callback.invoke(parse(capmlFile.inputStream()))
+    }
+
+    /**
+     * Takes the [capmlInputData] and opens a stream to it.
+     * Manually iterates through bytes.
+     * Looks for the .capml...decorators? Flags?
+     * Once it has finished assembling the scrollview, executes a callback
+     * using the view
+     *
+     * @return [Unit]
+     */
+    @Throws(CapmlFileFormatException::class, CapmlParseException::class)
+    suspend fun parse(
+        capmlFile: InputStream,
+        callback:((View) -> Unit)
+    ){
+        callback.invoke(parse(capmlFile))
+    }
+
+
     /**
      * Takes the [capmlFile] and opens a stream to it.
      * Manually iterates through bytes.


### PR DESCRIPTION
Essentially removed the ability for the parsing of the file to be done on the UI thread. It's fast enough that doing so on the UI thread skips less than 200 frames while rendering 1000 spinners with 10 items per dropdown, but regardless main thread is not the way.